### PR TITLE
📝 docs(readme): 更新语言切换链接和仓库引用，修复openclaw仓库地址错误

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,8 +6,7 @@
   <b>OpenOcta</b> — A Go‑based, enterprise‑oriented observability & operations agent
 </p>
 
-> 中文说明请见 `README.md`。  
-> For the Chinese version, see `README.md`.
+> English | [简体中文](README.md)
 
 OpenOcta is built on the [OpenClaw](https://github.com/openocta/openocta) Gateway protocol and Control UI, and is rewritten as a **single Go binary backend with an embedded frontend**, targeting headless enterprise servers for observability, operations, and automation scenarios.
 
@@ -115,7 +114,7 @@ On first run, if no config file exists, OpenOcta initializes one from the embedd
 
 Upstream references:
 
-- [OpenClaw repository](https://github.com/openocta/openocta)
+- [OpenClaw repository](https://github.com/openclaw/openclaw)
 - [docs.openclaw.ai](https://docs.openclaw.ai) — official Gateway & configuration docs
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
   <b>OpenOcta 八爪鱼</b> —— 开源企业级智能体，专为运维而生
 </p>
 
-> English version: see `README.en.md`.  
-> 英文说明请查看 `README.en.md`。
+> [English](README.en.md) | 简体中文
 
 OpenOcta 基于 [OpenClaw](https://github.com/openocta/openocta) 的 Gateway 协议和 Control UI，重写为 **单一 Go 二进制后端 + 内嵌前端**，面向无桌面服务器环境下的运维、可观测与自动化场景。
 
@@ -116,7 +115,7 @@ export ANTHROPIC_API_KEY=your-key
 
 上游参考：
 
-- [OpenClaw 官方仓库](https://github.com/openocta/openocta)
+- [OpenClaw 官方仓库](https://github.com/openclaw/openclaw)
 - [docs.openclaw.ai](https://docs.openclaw.ai)（包含 Gateway 协议、配置等官方文档）
 
 ---


### PR DESCRIPTION
- 统一中英文 README 的语言切换格式。
- 修正 OpenClaw 仓库链接为正确的地址。