### PR TITLE
fix(gateway): honor gateway.bind for listen address

### DIFF
--- a/src/cmd/openocta/commands/gateway.go
+++ b/src/cmd/openocta/commands/gateway.go
@@ -119,11 +119,13 @@ func runGateway(cmd *cobra.Command, _ []string) error {
 		logging.Warn("Gateway config load failed: %v", cfgErr)
 	}
 	var cfgMode *string
+	var cfgBind *string
 	if cfg != nil && cfg.Gateway != nil {
 		cfgMode = cfg.Gateway.Mode
+		cfgBind = cfg.Gateway.Bind
 	}
 	runMode := paths.ResolveRunMode(env, cfgMode)
-	addr := paths.ResolveGatewayAddr(port, runMode)
+	addr := paths.ResolveGatewayAddrWithBind(port, runMode, cfgBind)
 
 	cmd.Printf("Starting Gateway on %s (mode=%s, OpenOcta %s)\n", addr, runMode, version.Version)
 	logging.Info("Gateway starting addr=%s mode=%s version=%s", addr, runMode, version.Version)

--- a/src/pkg/desktop/gateway.go
+++ b/src/pkg/desktop/gateway.go
@@ -63,11 +63,13 @@ func StartGateway() (*gatewayhttp.Server, error) {
 		logging.Warn("Gateway config load failed: %v", cfgErr)
 	}
 	var cfgMode *string
+	var cfgBind *string
 	if cfg != nil && cfg.Gateway != nil {
 		cfgMode = cfg.Gateway.Mode
+		cfgBind = cfg.Gateway.Bind
 	}
 	runMode := paths.ResolveRunMode(env, cfgMode)
-	addr := paths.ResolveGatewayAddr(DesktopPort, runMode)
+	addr := paths.ResolveGatewayAddrWithBind(DesktopPort, runMode, cfgBind)
 
 	logging.Info("Desktop gateway starting addr=%s mode=%s version=%s", addr, runMode, version.Version)
 

--- a/src/pkg/paths/paths.go
+++ b/src/pkg/paths/paths.go
@@ -2,9 +2,11 @@ package paths
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -221,8 +223,45 @@ func ResolveRunMode(env func(string) string, gatewayModeFromConfig *string) stri
 // - desktop: 127.0.0.1:port (loopback-only)
 // - service: :port (all interfaces)
 func ResolveGatewayAddr(port int, runMode string) string {
+	return ResolveGatewayAddrWithBind(port, runMode, nil)
+}
+
+// ResolveGatewayAddrWithBind returns the listen address for the given port, run mode and bind config.
+//
+// bind supports:
+// - loopback / localhost / 127.0.0.1 / ::1 => loopback-only
+// - lan / 0.0.0.0 / :: / * => all interfaces
+// - auto / empty => fallback to run mode
+// - any other non-empty value => treat as explicit host and join with port
+func ResolveGatewayAddrWithBind(port int, runMode string, bindFromConfig *string) string {
+	if host, ok := resolveGatewayBindHost(bindFromConfig); ok {
+		return net.JoinHostPort(host, strconv.Itoa(port))
+	}
+
 	if strings.EqualFold(strings.TrimSpace(runMode), "desktop") {
 		return fmt.Sprintf("127.0.0.1:%d", port)
 	}
 	return fmt.Sprintf(":%d", port)
+}
+
+func resolveGatewayBindHost(bindFromConfig *string) (string, bool) {
+	if bindFromConfig == nil {
+		return "", false
+	}
+	raw := strings.TrimSpace(*bindFromConfig)
+	if raw == "" {
+		return "", false
+	}
+	norm := strings.ToLower(raw)
+	switch norm {
+	case "auto":
+		return "", false
+	case "loopback", "localhost", "127.0.0.1":
+		return "127.0.0.1", true
+	case "::1":
+		return "::1", true
+	case "lan", "0.0.0.0", "::", "*":
+		return "", true
+	}
+	return raw, true
 }

--- a/src/pkg/paths/paths_test.go
+++ b/src/pkg/paths/paths_test.go
@@ -36,3 +36,35 @@ func TestDefaultGatewayPort(t *testing.T) {
 		t.Errorf("expected 18900, got %d", DefaultGatewayPort())
 	}
 }
+
+func TestResolveGatewayAddrWithBind_LoopbackAliases(t *testing.T) {
+	runMode := "service"
+	localhost := "localhost"
+	loopback := "loopback"
+
+	addr1 := ResolveGatewayAddrWithBind(18900, runMode, &localhost)
+	if addr1 != "127.0.0.1:18900" {
+		t.Fatalf("expected localhost bind to resolve loopback, got %q", addr1)
+	}
+
+	addr2 := ResolveGatewayAddrWithBind(18900, runMode, &loopback)
+	if addr2 != "127.0.0.1:18900" {
+		t.Fatalf("expected loopback bind to resolve loopback, got %q", addr2)
+	}
+}
+
+func TestResolveGatewayAddrWithBind_AllInterfacesAliases(t *testing.T) {
+	runMode := "desktop"
+	lan := "lan"
+	anyV4 := "0.0.0.0"
+
+	addr1 := ResolveGatewayAddrWithBind(18900, runMode, &lan)
+	if addr1 != ":18900" {
+		t.Fatalf("expected lan bind to resolve all interfaces, got %q", addr1)
+	}
+
+	addr2 := ResolveGatewayAddrWithBind(18900, runMode, &anyV4)
+	if addr2 != ":18900" {
+		t.Fatalf("expected 0.0.0.0 bind to resolve all interfaces, got %q", addr2)
+	}
+}


### PR DESCRIPTION
### Motivation
- 修复 `gateway.bind` 配置不生效的问题，Issue 中反馈在设置 `bind`（如 `localhost`）时仍然会监听在 `:::18900`，导致无法限定为 loopback-only。

### Description
- 新增 `ResolveGatewayAddrWithBind(port, runMode, bindFromConfig *string)`，优先根据 `bind` 解析监听地址并支持别名（`loopback`/`localhost`/`127.0.0.1`/`::1` -> loopback，`lan`/`0.0.0.0`/`::`/`*` -> all interfaces，`auto`/空值回退到 `runMode`）并支持显式主机名。
- 将 CLI 启动路径（`src/cmd/openocta/commands/gateway.go`）和桌面启动路径（`src/pkg/desktop/gateway.go`）改为使用 `ResolveGatewayAddrWithBind` 并传入 `cfg.Gateway.Bind`，使 `gateway.bind` 生效。
- 在 `src/pkg/paths/paths.go` 中添加 `resolveGatewayBindHost` 辅助函数并调整 `ResolveGatewayAddr` 为兼容前向调用。
- 添加单元测试 `TestResolveGatewayAddrWithBind_LoopbackAliases` 和 `TestResolveGatewayAddrWithBind_AllInterfacesAliases` 于 `src/pkg/paths/paths_test.go` 验证别名解析逻辑。

### Testing
- 运行 `go test ./pkg/paths` 在本地包级别通过并返回 `ok`，测试新增用例均通过。 ✅
- 试图运行 `go test ./pkg/paths ./cmd/openocta/commands ./pkg/desktop` 时 setup 失败并非本次变更错误，而是当前环境缺少嵌入的 `frontend` 资源导致相关包无法 setup（embed 资源缺失），因此整体命令在此环境下失败。 ⚠️
- 修改的主要文件：`src/pkg/paths/paths.go`, `src/cmd/openocta/commands/gateway.go`, `src/pkg/desktop/gateway.go`, `src/pkg/paths/paths_test.go`。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c38ebfc5c08324b1061ca3f1a8d5b7)