### PR TITLE
fix(qq): filter non-final stream chunks in replies

### DIFF
--- a/src/pkg/channels/qq/runtime.go
+++ b/src/pkg/channels/qq/runtime.go
@@ -248,13 +248,18 @@ func (r *Runtime) SendStream(chatID string, stream <-chan *channels.RuntimeStrea
 		if chunk.Error != "" {
 			return fmt.Errorf("qq runtime stream error: %s", chunk.Error)
 		}
-		if !chunk.IsThinking {
+		// 过滤非最终结果类型，避免将思考阶段/中间态内容（如 "."）发送到 QQ。
+		if !chunk.IsThinking && chunk.IsFinal {
 			buf.WriteString(chunk.Content)
 		}
 		if chunk.IsComplete {
 			break
 		}
 	}
+	if buf.Len() == 0 {
+		return nil
+	}
+
 	return r.Send(&channels.RuntimeOutboundMessage{
 		ChatID:  chatID,
 		Content: buf.String(),


### PR DESCRIPTION
### Motivation
- Prevent intermediate/think-only chunks (e.g. ".") from being delivered to QQ and align QQ reply behavior with other channel adapters.

### Description
- In `src/pkg/channels/qq/runtime.go` modified `SendStream` to only buffer chunks when `!chunk.IsThinking && chunk.IsFinal`.
- Added an early-return guard to skip sending when the aggregated buffer is empty.

### Testing
- Ran `go test ./pkg/channels/qq` (from `src/`), which completed (package has no tests but the build path succeeded).
- Running multi-package tests including `dingtalk` and `feishu` in this environment failed due to missing static embed files referenced by `embed/embed.go`, which is an environment/setup issue rather than related to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3ba363c988324a34e729c7ec1f745)