### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+OpenOcta is an open-source enterprise AI agent platform (single Go binary + embedded Lit/Vite frontend). The Gateway serves the Control UI and WebSocket API on port 18900.
+
+### System requirements
+
+- **Go 1.25+** (the `go.mod` declares `go 1.25`; Go 1.22 will NOT work)
+- **Node >= 18** (only needed for frontend build/dev)
+
+### Building
+
+See `Makefile` targets. The primary build flow:
+
+- `make build` — builds frontend → embeds into Go binary → compiles `openocta`
+- `make run` — builds + starts Gateway on `:18900`
+- `make run-ui` — starts Vite dev server on `:5173`
+
+### Running services for development
+
+1. **Gateway** (backend): `OPENOCTA_SKIP_CHANNELS=1 OPENOCTA_SKIP_CRON=1 ./openocta gateway run` — starts on `127.0.0.1:18900`. Skip channels/cron avoids needing external messaging credentials.
+2. **Frontend dev server**: `cd ui && npm run dev` — Vite dev server on `:5173` with hot reload. Connect to the Gateway via WebSocket.
+
+A gateway auth token is auto-generated in `~/.openocta/openocta.json` on first run.
+
+### Testing
+
+- **Go backend**: `cd src && go test ./...` — unit tests pass; the 3 tests in `test/gateway_protocol_test.go` are integration tests that require a running Gateway with valid auth config and may fail without it.
+- **Frontend**: `cd ui && npm test` — runs Vitest with Playwright (Chromium). Requires `npx playwright install --with-deps chromium` first.
+
+### Linting
+
+- **Go**: `cd src && go vet ./...`
+- **TypeScript**: `cd ui && npx tsc --noEmit` (pre-existing type errors exist in the codebase)
+- No ESLint or golangci-lint configurations are present.
+
+### Key env vars
+
+| Variable | Purpose |
+|---|---|
+| `OPENOCTA_SKIP_CHANNELS` | Set to `1` to skip loading messaging channels (avoids needing Discord/Telegram/etc. tokens) |
+| `OPENOCTA_SKIP_CRON` | Set to `1` to skip cron service |
+| `ANTHROPIC_API_KEY` | Required for agent chat functionality (LLM calls) |
+
+### Gotchas
+
+- The Makefile `ui` target uses `npm install && npm run build`; the `ui/README.md` recommends pnpm. Both `package-lock.json` and `pnpm-lock.yaml` exist. Use npm to match the Makefile.
+- The frontend build output goes to `src/embed/frontend/` and is embedded into the Go binary via `go:embed`.
+- SQLite, Bleve search, and BoltDB are all embedded pure-Go libraries — no external database processes needed.
+- State directory defaults to `~/.openocta/`. Config is at `~/.openocta/openocta.json`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment setup instructions for Cursor Cloud agents, covering:

- Project overview and system requirements (Go 1.25+, Node >= 18)
- Build and run commands referencing the existing `Makefile`
- How to start the Gateway and frontend dev server for development
- Testing instructions (Go unit tests, Vitest + Playwright for frontend)
- Lint commands (`go vet`, `tsc --noEmit`)
- Key environment variables (`OPENOCTA_SKIP_CHANNELS`, `ANTHROPIC_API_KEY`, etc.)
- Gotchas discovered during setup (npm vs pnpm, embedded frontend, state directory)

## Verification

All services verified working:

| Service | Command | Status |
|---|---|---|
| Build | `make build` | Compiled successfully |
| Go tests | `cd src && go test ./...` | 5 packages pass; 3 integration tests need running Gateway |
| Frontend tests | `cd ui && npm test` | 203/203 tests pass (16 test files) |
| Go lint | `cd src && go vet ./...` | Clean |
| TS type check | `cd ui && npx tsc --noEmit` | Pre-existing type errors (not introduced by this PR) |
| Gateway | `./openocta gateway run` | Runs on :18900, WebSocket API functional |
| Frontend dev | `cd ui && npm run dev` | Vite dev server on :5173, UI fully functional |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fa11dd6-6252-439c-8dcf-81a6f28a8ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fa11dd6-6252-439c-8dcf-81a6f28a8ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

