### PR TITLE
fix/消息聊天中最后一个用户消息重复

### DIFF
--- a/src/pkg/agent/runtime/session_history.go
+++ b/src/pkg/agent/runtime/session_history.go
@@ -95,7 +95,19 @@ func defaultSessionHistoryLoader(projectRoot string, opts Options, cfg *config.S
 		if tErr != nil || len(tmsgs) == 0 {
 			return nil, nil
 		}
-		return transcriptMessagesToSDK(tmsgs), nil
+
+		// Truncate to last assistant message, so as to avoid duplicated current user message
+		converted := transcriptMessagesToSDK(tmsgs)
+		lastAssistant := -1
+		for i, msg := range converted {
+			if strings.EqualFold(msg.Role, "assistant") {
+				lastAssistant = i
+			}
+		}
+		if lastAssistant < 0 {
+			return nil, nil
+		}
+		return converted[:lastAssistant+1], nil
 	}
 }
 


### PR DESCRIPTION
# Bug表现
每轮对话中，发送给模型的 message 列表里，当前轮用户消息会出现两次，可能会导致指令重复执行两次。

# Bug原因
原因是从transcript文件中取history时，当前history已经携带了当前轮对话，而之后 agentsdk 还会再zh追加一轮当前轮消息。
<img width="1042" height="805" alt="image" src="https://github.com/user-attachments/assets/d78d8ec8-3f6d-496d-8fd1-ac69eba1ac49" />

# 修复方式
session_history.go 的 transcript fallback 截断到最后一条 assistant消息，只返回**已完成的轮次**，当前用户消息由SDK追加。

# 修复后效果
<img width="1169" height="453" alt="image" src="https://github.com/user-attachments/assets/0bddd9b3-715b-4813-8426-ee9806ee15a6" />
