### PR TITLE
fix: add CustomBashTool stub for non-Windows platforms

### DIFF
--- a/src/pkg/agent/tools/custom_bash_other.go
+++ b/src/pkg/agent/tools/custom_bash_other.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package tools
+
+import (
+	"context"
+
+	"github.com/stellarlinkco/agentsdk-go/pkg/tool"
+)
+
+// CustomBashTool is a stub on non-Windows platforms.
+type CustomBashTool struct{}
+
+func (CustomBashTool) Name() string        { return "bash" }
+func (CustomBashTool) Description() string { return "stub" }
+func (CustomBashTool) Schema() *tool.JSONSchema {
+	return &tool.JSONSchema{Type: "object"}
+}
+func (CustomBashTool) Execute(_ context.Context, _ map[string]interface{}) (*tool.ToolResult, error) {
+	return &tool.ToolResult{Success: false, Output: "CustomBashTool is only available on Windows"}, nil
+}


### PR DESCRIPTION
## Summary
- `CustomBashTool` is defined in `custom_bash_windows.go` with `//go:build windows`
- This causes `undefined: tools.CustomBashTool` when cross-compiling for Linux
- Add `custom_bash_other.go` with `//go:build !windows` to provide a stub implementation

## Test plan
- [ ] Verify `GOOS=linux GOARCH=amd64 go build ./...` passes
- [ ] Verify `GOOS=linux GOARCH=arm64 go build ./...` passes
- [ ] Verify Windows build still works

🤖 Generated with [Qoder][https://qoder.com]