### PR TITLE
Quality: Stale environment variable name OPENCLAW_CONTROL_UI_BASE_PATH after project rename

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -19,7 +19,7 @@ function normalizeBase(input: string): string {
 }
 
 export default defineConfig(() => {
-  const envBase = process.env.OPENCLAW_CONTROL_UI_BASE_PATH?.trim();
+  const envBase = (process.env.OPENOCTA_CONTROL_UI_BASE_PATH ?? process.env.OPENCLAW_CONTROL_UI_BASE_PATH)?.trim();
   const base = envBase ? normalizeBase(envBase) : "./";
   return {
     base,


### PR DESCRIPTION
## Problem

The environment variable `OPENCLAW_CONTROL_UI_BASE_PATH` references the old project name "openclaw" while the project is now "openocta". The rest of the codebase consistently uses the `OPENOCTA_` prefix (e.g., `OPENOCTA_CONFIG_PATH` in docs/configuration.md). Users who set `OPENOCTA_CONTROL_UI_BASE_PATH` following the project convention will silently get the default `"./"` base path instead of their configured value, breaking sub-path deployments (e.g., serving the UI under `/admin/`).


**Severity**: `medium`
**File**: `ui/vite.config.ts`

## Solution

The environment variable `OPENCLAW_CONTROL_UI_BASE_PATH` references the old project name "openclaw" while the project is now "openocta". The rest of the codebase consistently uses the `OPENOCTA_` prefix (e.g., `OPENOCTA_CONFIG_PATH` in docs/configuration.md). Users who set `OPENOCTA_CONTROL_UI_BASE_PATH` following the project convention will silently get the default `"./"` base path instead of their configured value, breaking sub-path deployments (e.g., serving the UI under `/admin/`).


## Changes

- `ui/vite.config.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
