### PR TITLE
fix: add MCP server command allowlist to prevent RCE via config API

### DIFF
--- a/src/pkg/acp/mcp/manager.go
+++ b/src/pkg/acp/mcp/manager.go
@@ -56,6 +56,10 @@ func connectEntry(ctx context.Context, key string, e *config.McpServerEntry) (*C
 
 	if command != "" {
 		// Direct: run command with args and env (stdio)
+		// Validate command against allowlist before execution (defense-in-depth RCE prevention).
+		if err := config.ValidateMcpCommand(command); err != nil {
+			return nil, fmt.Errorf("mcp server %q: %w", key, err)
+		}
 		env := flattenEnv(e.Env)
 		return ConnectStdio(ctx, key, command, e.Args, env)
 	}

--- a/src/pkg/config/mcp_validate.go
+++ b/src/pkg/config/mcp_validate.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AllowedMCPCommands is the set of commands permitted for MCP server stdio execution.
+// Only MCP package launchers are included — NOT general-purpose runtimes like python/node
+// because they accept -c/-e flags for arbitrary code execution when args are user-controlled.
+// Similarly, docker is excluded because -v/--privileged can escape container isolation.
+//
+// For Docker-based MCP servers, use the built-in Service mode (Service+ServiceURL fields)
+// which resolves commands from hardcoded safe mappings in resolveServiceServer().
+var AllowedMCPCommands = map[string]bool{
+	"npx": true, // Node.js MCP package runner
+	"uvx": true, // Python MCP package runner (uv)
+	"uv":  true, // Python package manager / runner
+}
+
+// BlockedMCPCommands are shell interpreters and other dangerous commands
+// that are explicitly blocked even if they somehow pass other checks.
+var BlockedMCPCommands = map[string]bool{
+	"bash": true, "sh": true, "zsh": true, "dash": true, "fish": true,
+	"cmd": true, "cmd.exe": true, "powershell": true, "powershell.exe": true,
+	"pwsh": true, "csh": true, "tcsh": true, "ksh": true,
+}
+
+// ValidateMcpCommand checks that an MCP server command is safe for execution.
+// It rejects:
+//   - Shell interpreters (bash, sh, cmd, powershell, etc.)
+//   - Commands containing path separators (/ or \) to prevent absolute/relative path execution
+//   - Commands not in the allowed list (npx, uvx, uv)
+//
+// An empty command passes validation (used for URL-based or service-based MCP servers).
+func ValidateMcpCommand(command string) error {
+	cmd := strings.TrimSpace(command)
+	if cmd == "" {
+		// Empty command is valid — the server uses URL or Service+ServiceURL mode
+		return nil
+	}
+
+	// Block commands with path separators (absolute or relative paths).
+	// This prevents attacks like:
+	//   /bin/bash, C:\Windows\System32\cmd.exe, ./malicious, ..\..\evil
+	if strings.ContainsAny(cmd, "/\\") {
+		return fmt.Errorf("mcp command %q must not contain path separators; use a command name without path", cmd)
+	}
+
+	// Normalize: strip .exe/.cmd suffix on Windows for comparison
+	baseName := strings.ToLower(cmd)
+	baseName = strings.TrimSuffix(baseName, ".exe")
+	baseName = strings.TrimSuffix(baseName, ".cmd")
+
+	// Block shell interpreters (both Unix and Windows)
+	if BlockedMCPCommands[baseName] {
+		return fmt.Errorf("mcp command %q is a shell interpreter; shell interpreters are not allowed as MCP server commands", cmd)
+	}
+
+	// Allowlist check — the command must be in the allowed set
+	if !AllowedMCPCommands[cmd] && !AllowedMCPCommands[baseName] {
+		return fmt.Errorf("mcp command %q is not in the allowed list (allowed: npx, uvx, uv)", cmd)
+	}
+
+	return nil
+}
+
+// ValidateMcpServers validates the command field of every enabled MCP server entry.
+// Disabled servers are skipped (they won't be executed).
+func ValidateMcpServers(servers map[string]McpServerEntry) error {
+	for key, entry := range servers {
+		if !entry.Enabled {
+			continue
+		}
+		if err := ValidateMcpCommand(entry.Command); err != nil {
+			return fmt.Errorf("mcp server %q: %w", key, err)
+		}
+	}
+	return nil
+}

--- a/src/pkg/gateway/handlers/config.go
+++ b/src/pkg/gateway/handlers/config.go
@@ -330,6 +330,16 @@ func ConfigPatchHandler(opts HandlerOpts) error {
 	// Use raw file content as base to preserve all keys (struct marshal drops omitempty/extra keys)
 	baseMap := ConfigSnapshotToMap(snap)
 	merged := mergePatch(baseMap, patch)
+
+	// Validate MCP server commands before writing to disk (RCE prevention).
+	if err := validateMcpInMergedConfig(merged); err != nil {
+		opts.Respond(false, nil, &protocol.ErrorShape{
+			Code:    protocol.ErrCodeInvalidRequest,
+			Message: err.Error(),
+		}, nil)
+		return nil
+	}
+
 	data, err := json.MarshalIndent(merged, "", "  ")
 	if err != nil {
 		opts.Respond(false, nil, &protocol.ErrorShape{
@@ -472,6 +482,24 @@ func ConfigSnapshotToMap(snap *ConfigSnapshot) map[string]interface{} {
 		}
 	}
 	return map[string]interface{}{}
+}
+
+// validateMcpInMergedConfig checks MCP server commands in a merged config map
+// before writing to disk. Returns nil if validation passes, or an error describing the violation.
+func validateMcpInMergedConfig(merged map[string]interface{}) error {
+	data, err := json.Marshal(merged)
+	if err != nil {
+		return err
+	}
+	var cfg config.OpenOctaConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		// If the merged config can't be parsed, skip MCP validation.
+		return nil
+	}
+	if cfg.Mcp == nil || len(cfg.Mcp.Servers) == 0 {
+		return nil
+	}
+	return config.ValidateMcpServers(cfg.Mcp.Servers)
 }
 
 // WriteConfigMap writes a config map to the given path, preserving all keys.

--- a/src/pkg/gateway/http/config_api.go
+++ b/src/pkg/gateway/http/config_api.go
@@ -166,6 +166,13 @@ func (s *Server) handleConfigPatch(w http.ResponseWriter, r *http.Request) {
 	// Use raw file content as base to preserve all keys (struct marshal drops omitempty/extra keys)
 	baseMap := handlers.ConfigSnapshotToMap(snap)
 	merged := mergePatchForAPI(baseMap, req.Patch)
+
+	// Validate MCP server commands before writing to disk (RCE prevention).
+	if err := validateMcpInMergedConfig(merged); err != nil {
+		writeConfigPatchError(w, err.Error())
+		return
+	}
+
 	data, err := json.MarshalIndent(merged, "", "  ")
 	if err != nil {
 		writeConfigPatchError(w, err.Error())
@@ -195,6 +202,26 @@ func (s *Server) handleConfigPatch(w http.ResponseWriter, r *http.Request) {
 func writeConfigPatchError(w http.ResponseWriter, msg string) {
 	w.WriteHeader(http.StatusBadRequest)
 	_ = json.NewEncoder(w).Encode(configPatchResponse{OK: false, Error: msg})
+}
+
+// validateMcpInMergedConfig checks MCP server commands in a merged config map
+// before writing to disk. Returns nil if validation passes, or an error describing the violation.
+func validateMcpInMergedConfig(merged map[string]interface{}) error {
+	// Re-marshal and unmarshal into typed config to extract MCP servers.
+	data, err := json.Marshal(merged)
+	if err != nil {
+		return err
+	}
+	var cfg config.OpenOctaConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		// If the merged config can't be parsed, skip MCP validation.
+		// The config write will likely fail or the next load will catch the issue.
+		return nil
+	}
+	if cfg.Mcp == nil || len(cfg.Mcp.Servers) == 0 {
+		return nil
+	}
+	return config.ValidateMcpServers(cfg.Mcp.Servers)
 }
 
 func mergePatchForAPI(base, patch map[string]interface{}) map[string]interface{} {

--- a/src/pkg/gateway/http/site_install.go
+++ b/src/pkg/gateway/http/site_install.go
@@ -591,6 +591,11 @@ func installMcp(zipData []byte, typeVal, fromVal string, env func(string) string
 		enabled = *entry.Enabled
 	}
 
+	// Validate MCP command before writing to config (RCE prevention).
+	if err := config.ValidateMcpCommand(entry.Command); err != nil {
+		return "", fmt.Errorf("config.json 中 %q 的 command 无效: %w", firstKey, err)
+	}
+
 	mcpEntry := config.McpServerEntry{
 		Command: entry.Command,
 		Args:    entry.Args,

--- a/src/test/mcp_validate_test.go
+++ b/src/test/mcp_validate_test.go
@@ -1,0 +1,193 @@
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openocta/openocta/pkg/config"
+)
+
+func TestValidateMcpCommand_AllowedCommands(t *testing.T) {
+	allowed := []string{"npx", "uvx", "uv"}
+	for _, cmd := range allowed {
+		t.Run(cmd, func(t *testing.T) {
+			if err := config.ValidateMcpCommand(cmd); err != nil {
+				t.Errorf("ValidateMcpCommand(%q) should pass but got: %v", cmd, err)
+			}
+		})
+	}
+}
+
+func TestValidateMcpCommand_EmptyCommand(t *testing.T) {
+	tests := []string{"", "  ", "\t"}
+	for _, cmd := range tests {
+		t.Run("empty_"+cmd, func(t *testing.T) {
+			if err := config.ValidateMcpCommand(cmd); err != nil {
+				t.Errorf("ValidateMcpCommand(%q) should pass for empty command but got: %v", cmd, err)
+			}
+		})
+	}
+}
+
+func TestValidateMcpCommand_BlockedShells(t *testing.T) {
+	blocked := []string{
+		"bash", "sh", "zsh", "dash", "fish",
+		"cmd", "cmd.exe", "powershell", "powershell.exe",
+		"pwsh", "csh", "tcsh", "ksh",
+	}
+	for _, cmd := range blocked {
+		t.Run(cmd, func(t *testing.T) {
+			if err := config.ValidateMcpCommand(cmd); err == nil {
+				t.Errorf("ValidateMcpCommand(%q) should fail (blocked shell) but passed", cmd)
+			}
+		})
+	}
+}
+
+func TestValidateMcpCommand_BlockedPaths(t *testing.T) {
+	blocked := []string{
+		"/bin/bash",
+		"/usr/bin/sh",
+		"/bin/zsh",
+		"C:\\Windows\\System32\\cmd.exe",
+		"./malicious",
+		"../evil",
+		"../../bad",
+		"\\evil\\path",
+	}
+	for _, cmd := range blocked {
+		t.Run(cmd, func(t *testing.T) {
+			if err := config.ValidateMcpCommand(cmd); err == nil {
+				t.Errorf("ValidateMcpCommand(%q) should fail (contains path separator) but passed", cmd)
+			} else if !strings.Contains(err.Error(), "path separator") {
+				t.Errorf("ValidateMcpCommand(%q) should mention 'path separator' but got: %v", cmd, err)
+			}
+		})
+	}
+}
+
+func TestValidateMcpCommand_BlockedUnknown(t *testing.T) {
+	// Arbitrary commands that are not in the allowlist - should all be rejected.
+	// docker/python/node are also blocked despite being "legitimate" tools,
+	// because with user-controlled args they enable arbitrary code execution
+	// (docker -v mount escape, python -c, node -e).
+	blocked := []string{"touch", "curl", "wget", "nc", "netcat", "ssh", "telnet", "perl", "ruby", "php", "docker", "python", "python3", "node"}
+	for _, cmd := range blocked {
+		t.Run(cmd, func(t *testing.T) {
+			if err := config.ValidateMcpCommand(cmd); err == nil {
+				t.Errorf("ValidateMcpCommand(%q) should fail (not in allowlist) but passed", cmd)
+			}
+		})
+	}
+}
+
+func TestValidateMcpCommand_ExeSuffixNormalization(t *testing.T) {
+	// On Windows, commands may be specified with .exe and should normalize to the allowlist.
+	tests := []string{"npx.exe", "uvx.exe", "uv.exe"}
+	for _, cmd := range tests {
+		t.Run(cmd, func(t *testing.T) {
+			if err := config.ValidateMcpCommand(cmd); err != nil {
+				t.Errorf("ValidateMcpCommand(%q) should pass (normalized to allowed command) but got: %v", cmd, err)
+			}
+		})
+	}
+}
+
+func TestValidateMcpCommand_CmdSuffixNormalization(t *testing.T) {
+	tests := []string{"npx.cmd", "uvx.cmd"}
+	for _, cmd := range tests {
+		t.Run(cmd, func(t *testing.T) {
+			if err := config.ValidateMcpCommand(cmd); err != nil {
+				t.Errorf("ValidateMcpCommand(%q) should pass (normalized to allowed command) but got: %v", cmd, err)
+			}
+		})
+	}
+}
+
+func TestValidateMcpCommand_BlockedShellWithExeSuffix(t *testing.T) {
+	// Shell interpreters with .exe suffix should still be blocked.
+	tests := []string{"bash.exe", "sh.exe", "powershell.exe"}
+	for _, cmd := range tests {
+		t.Run(cmd, func(t *testing.T) {
+			if err := config.ValidateMcpCommand(cmd); err == nil {
+				t.Errorf("ValidateMcpCommand(%q) should fail (blocked shell with .exe) but passed", cmd)
+			}
+		})
+	}
+}
+
+func TestValidateMcpCommand_TrailingWhitespace(t *testing.T) {
+	// Commands with whitespace should be trimmed and still work.
+	if err := config.ValidateMcpCommand("  npx  "); err != nil {
+		t.Errorf("ValidateMcpCommand('  npx  ') should pass after trimming but got: %v", err)
+	}
+	if err := config.ValidateMcpCommand("  bash  "); err == nil {
+		t.Errorf("ValidateMcpCommand('  bash  ') should fail (blocked shell) but passed")
+	}
+}
+
+func TestValidateMcpServers_AllValid(t *testing.T) {
+	servers := map[string]config.McpServerEntry{
+		"npx-server":      {Enabled: true, Command: "npx"},
+		"uvx-server":      {Enabled: true, Command: "uvx"},
+		"url-server":      {Enabled: true, Command: "", URL: "http://localhost:8080"},
+		"disabled-server": {Enabled: false, Command: "touch"}, // disabled, should be skipped
+	}
+	if err := config.ValidateMcpServers(servers); err != nil {
+		t.Errorf("ValidateMcpServers should pass for valid config but got: %v", err)
+	}
+}
+
+func TestValidateMcpServers_InvalidCommand(t *testing.T) {
+	servers := map[string]config.McpServerEntry{
+		"bad-server": {Enabled: true, Command: "touch"},
+	}
+	if err := config.ValidateMcpServers(servers); err == nil {
+		t.Errorf("ValidateMcpServers should fail for invalid command but passed")
+	} else if !strings.Contains(err.Error(), "bad-server") {
+		t.Errorf("ValidateMcpServers error should mention server key 'bad-server' but got: %v", err)
+	}
+}
+
+func TestValidateMcpServers_EmptyServers(t *testing.T) {
+	if err := config.ValidateMcpServers(nil); err != nil {
+		t.Errorf("ValidateMcpServers(nil) should pass but got: %v", err)
+	}
+	if err := config.ValidateMcpServers(map[string]config.McpServerEntry{}); err != nil {
+		t.Errorf("ValidateMcpServers({}) should pass but got: %v", err)
+	}
+}
+
+func TestValidateMcpServers_AllDisabled(t *testing.T) {
+	servers := map[string]config.McpServerEntry{
+		"bad-1": {Enabled: false, Command: "touch"},
+		"bad-2": {Enabled: false, Command: "/bin/bash"},
+	}
+	if err := config.ValidateMcpServers(servers); err != nil {
+		t.Errorf("ValidateMcpServers should skip disabled servers but got: %v", err)
+	}
+}
+
+func TestValidateMcpCommand_CaseInsensitiveShell(t *testing.T) {
+	// Shell interpreter names should be blocked regardless of case.
+	tests := []string{"BASH", "Bash", "CMD", "PowerShell", "POWERSHELL.EXE"}
+	for _, cmd := range tests {
+		t.Run(cmd, func(t *testing.T) {
+			if err := config.ValidateMcpCommand(cmd); err == nil {
+				t.Errorf("ValidateMcpCommand(%q) should fail (case-insensitive shell block) but passed", cmd)
+			}
+		})
+	}
+}
+
+func TestValidateMcpCommand_CaseSensitiveAllowlist(t *testing.T) {
+	// Allowlist is case-sensitive: exact match required.
+	tests := []string{"NPX", "Uvx", "UV"}
+	for _, cmd := range tests {
+		t.Run(cmd, func(t *testing.T) {
+			if err := config.ValidateMcpCommand(cmd); err == nil {
+				t.Errorf("ValidateMcpCommand(%q) should fail (case-sensitive allowlist) but passed", cmd)
+			}
+		})
+	}
+}


### PR DESCRIPTION
修复漏洞： CNVD-2026-25468
<img width="647" height="755" alt="image" src="https://github.com/user-attachments/assets/4f810a36-5ca5-4f38-8985-20916176c8c1" />


为MCP服务器配置添加命令允许列表验证，防止通过 /api/config/patch 端点执行任意命令

变更内容：
新增文件：
src/pkg/config/mcp_validate.go — 提供 ValidateMcpCommand/ValidateMcpServers 验证函数
src/pkg/config/mcp_validate_test.go — 包含 15 个单元测试用例


修改文件：
- New: src/pkg/config/mcp_validate_test.go — 15 unit tests
- Mod: HTTP config patch handler validates MCP commands before write
- Mod: Protocol config patch handler validates MCP commands before write
- Mod: MCP marketplace install validates commands from zip configs
- Mod: MCP manager validates commands before execution (defense-in-depth)

允许列表策略：
仅允许以下命令：npx、uvx、uv

拒绝以下类型：
Shell 解释器（bash、sh、cmd、powershell 等）
基于路径的命令（包含 / 或 \）
通用运行时（python、node、docker）

拒绝原因：这些命令的用户可控参数（如 -c、-e、-v 等标志）可被利用来执行任意代码，存在安全风险。

