### PR TITLE
Add MiniMax M3 to built-in providers

### DIFF
--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -496,9 +496,6 @@ The built-in `minimax` provider uses the global Anthropic-compatible endpoint an
 |-------|----------------|
 | `MiniMax-M3` | 1,000,000 tokens |
 | `MiniMax-M2.7` | 204,800 tokens |
-| `MiniMax-M2.7-highspeed` | Configure explicitly if enabled for your account |
-| `MiniMax-M2.5` | Configure explicitly if enabled for your account |
-| `MiniMax-M2.5-highspeed` | Configure explicitly if enabled for your account |
 
 Supported endpoint configurations:
 
@@ -573,7 +570,7 @@ To use another region or protocol, configure the existing provider through `mode
             "id": "MiniMax-M3",
             "name": "MiniMax M3",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": ["text", "image", "video"],
             "contextWindow": 1000000
           },
           {

--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -49,7 +49,7 @@
 | **qianfan**     | `QIANFAN_API_KEY`   | deepseek-v3-2-251201         | https://qianfan.baidubce.com/v2 | OpenAI |
 | **huggingface** | `HUGGINGFACE_HUB_TOKEN` | (需指定) | https://router.huggingface.co/v1 | OpenAI |
 | **xiaomi**      | `XIAOMI_API_KEY`    | mimo-v2-flash               | https://api.xiaomimimo.com/anthropic | Anthropic |
-| **minimax**     | `MINIMAX_API_KEY`   | MiniMax-M2.7                | https://api.minimax.io/anthropic | Anthropic |
+| **minimax**     | `MINIMAX_API_KEY`   | MiniMax-M3                  | https://api.minimax.io/anthropic | Anthropic |
 | **mistral**     | `MISTRAL_API_KEY`   | mistral-large-latest        | https://api.mistral.ai/v1 | OpenAI |
 | **groq**        | `GROQ_API_KEY`      | llama-3.3-70b-versatile     | https://api.groq.com/openai/v1 | OpenAI |
 | **cerebras**    | `CEREBRAS_API_KEY`  | llama-4-scout-17b-16e-instruct | https://api.cerebras.ai/v1 | OpenAI |
@@ -490,14 +490,28 @@ NEAR AI Cloud 提供 OpenAI 兼容端点，并支持 TEE 推理模型。默认�
 
 ### MiniMax
 
-MiniMax 提供 Anthropic Messages API 兼容端点，默认模型为最新的 `MiniMax-M2.7`（1M context）。可用模型：
+The built-in `minimax` provider uses the global Anthropic-compatible endpoint and defaults to `MiniMax-M3`. `MiniMax-M2.7` remains available as an explicit model selection.
 
-| 模型 | 说明 |
-|------|------|
-| `MiniMax-M2.7` | 最新旗舰模型，1M context |
-| `MiniMax-M2.7-highspeed` | 高速推理版本 |
-| `MiniMax-M2.5` | 上一代模型，204K context |
-| `MiniMax-M2.5-highspeed` | 上一代高速推理版本 |
+| Model | Context window |
+|-------|----------------|
+| `MiniMax-M3` | 1,000,000 tokens |
+| `MiniMax-M2.7` | 204,800 tokens |
+| `MiniMax-M2.7-highspeed` | Configure explicitly if enabled for your account |
+| `MiniMax-M2.5` | Configure explicitly if enabled for your account |
+| `MiniMax-M2.5-highspeed` | Configure explicitly if enabled for your account |
+
+Supported endpoint configurations:
+
+| Region | API type | Base URL |
+|--------|----------|----------|
+| `global_en` | `openai-completions` | `https://api.minimax.io/v1` |
+| `global_en` | `anthropic-messages` | `https://api.minimax.io/anthropic` |
+| `cn_zh` | `openai-completions` | `https://api.minimaxi.com/v1` |
+| `cn_zh` | `anthropic-messages` | `https://api.minimaxi.com/anthropic` |
+
+For Anthropic-compatible configuration, use the `/anthropic` Base URL directly. The client appends `/v1/messages`. For OpenAI-compatible configuration, the client appends `/chat/completions` to the `/v1` Base URL.
+
+Built-in global Anthropic-compatible configuration:
 
 ```json
 {
@@ -508,21 +522,21 @@ MiniMax 提供 Anthropic Messages API 兼容端点，默认模型为最新的 `M
   },
   "agents": {
     "defaults": {
-      "model": { "primary": "minimax/MiniMax-M2.7" }
+      "model": { "primary": "minimax/MiniMax-M3" }
     },
     "list": [
       {
         "id": "main",
         "default": true,
         "name": "Clawd",
-        "model": "minimax/MiniMax-M2.7"
+        "model": "minimax/MiniMax-M3"
       }
     ]
   }
 }
 ```
 
-使用高速推理版本：
+To select the retained model explicitly:
 
 ```json
 {
@@ -531,9 +545,52 @@ MiniMax 提供 Anthropic Messages API 兼容端点，默认模型为最新的 `M
       {
         "id": "main",
         "default": true,
-        "model": "minimax/MiniMax-M2.7-highspeed"
+        "model": "minimax/MiniMax-M2.7"
       }
     ]
+  }
+}
+```
+
+To use another region or protocol, configure the existing provider through `models.providers`. This example uses the China OpenAI-compatible endpoint while retaining both models:
+
+```json
+{
+  "env": {
+    "vars": {
+      "MINIMAX_API_KEY": "your-api-key"
+    }
+  },
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "minimax": {
+        "baseUrl": "https://api.minimaxi.com/v1",
+        "apiKey": "$MINIMAX_API_KEY",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "MiniMax-M3",
+            "name": "MiniMax M3",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000
+          },
+          {
+            "id": "MiniMax-M2.7",
+            "name": "MiniMax M2.7",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 204800
+          }
+        ]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": { "primary": "minimax/MiniMax-M3" }
+    }
   }
 }
 ```

--- a/src/pkg/agent/eino/model_factory.go
+++ b/src/pkg/agent/eino/model_factory.go
@@ -37,7 +37,7 @@ var builtInProviders = map[string]builtInProvider{
 	"qianfan":           {"https://qianfan.baidubce.com/v2", false, "QIANFAN_API_KEY", "deepseek-v3-2-251201"},
 	"huggingface":       {"https://router.huggingface.co/v1", false, "HUGGINGFACE_HUB_TOKEN", ""},
 	"xiaomi":            {"https://api.xiaomimimo.com/anthropic", true, "XIAOMI_API_KEY", "mimo-v2-flash"},
-	"minimax":           {"https://api.minimax.io/anthropic", true, "MINIMAX_API_KEY", "MiniMax-M2.7"},
+	"minimax":           {"https://api.minimax.io/anthropic", true, "MINIMAX_API_KEY", "MiniMax-M3"},
 	"mistral":           {"https://api.mistral.ai/v1", false, "MISTRAL_API_KEY", "mistral-large-latest"},
 	"groq":              {"https://api.groq.com/openai/v1", false, "GROQ_API_KEY", "llama-3.3-70b-versatile"},
 	"cerebras":          {"https://api.cerebras.ai/v1", false, "CEREBRAS_API_KEY", "llama-4-scout-17b-16e-instruct"},

--- a/src/pkg/agent/eino/model_factory_test.go
+++ b/src/pkg/agent/eino/model_factory_test.go
@@ -1,8 +1,12 @@
 package eino
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/cloudwego/eino/schema"
 
 	"github.com/openocta/openocta/pkg/config"
 )
@@ -41,17 +45,99 @@ func TestCreateModelFactoryFromConfig_MiniMax(t *testing.T) {
 		Models: &config.ModelsConfig{
 			Providers: map[string]config.ModelProvider{
 				"minimax": {
-					Models: []config.ModelDefinition{{ID: "MiniMax-M2.7"}},
+					Models: []config.ModelDefinition{{ID: "MiniMax-M3"}, {ID: "MiniMax-M2.7"}},
 				},
 			},
 		},
 	}
-	factory, err := CreateModelFactoryFromConfig(cfg, "minimax/MiniMax-M2.7")
+	factory, err := CreateModelFactoryFromConfig(cfg, "minimax/MiniMax-M3")
 	if err != nil {
 		t.Fatalf("CreateModelFactoryFromConfig: %v", err)
 	}
 	if factory == nil {
 		t.Fatal("expected non-nil factory")
+	}
+}
+
+func TestBuiltInMiniMaxProvider(t *testing.T) {
+	provider, ok := builtInProviders["minimax"]
+	if !ok {
+		t.Fatal("expected MiniMax built-in provider")
+	}
+	if provider.defaultModel != "MiniMax-M3" {
+		t.Fatalf("default model = %q, want MiniMax-M3", provider.defaultModel)
+	}
+	if provider.baseURL != "https://api.minimax.io/anthropic" {
+		t.Fatalf("base URL = %q, want global Anthropic-compatible base URL", provider.baseURL)
+	}
+	if !provider.useAnthropic {
+		t.Fatal("expected Anthropic-compatible adapter")
+	}
+}
+
+func TestMiniMaxCompatibleRequestPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		api      string
+		basePath string
+		wantPath string
+		response string
+	}{
+		{
+			name:     "Anthropic",
+			api:      "anthropic-messages",
+			basePath: "/anthropic",
+			wantPath: "/anthropic/v1/messages",
+			response: `{"id":"msg_test","type":"message","role":"assistant","model":"MiniMax-M3","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}`,
+		},
+		{
+			name:     "OpenAI",
+			api:      "openai-completions",
+			basePath: "/v1",
+			wantPath: "/v1/chat/completions",
+			response: `{"id":"chatcmpl_test","object":"chat.completion","created":0,"model":"MiniMax-M3","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			requestPath := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestPath <- r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.response))
+			}))
+			t.Cleanup(server.Close)
+
+			api := tc.api
+			maxTokens := 128
+			cfg := &config.OpenOctaConfig{
+				Models: &config.ModelsConfig{
+					Providers: map[string]config.ModelProvider{
+						"minimax-test": {
+							BaseURL: server.URL + tc.basePath,
+							APIKey:  "test-key",
+							API:     &api,
+							Models:  []config.ModelDefinition{{ID: "MiniMax-M3", MaxTokens: &maxTokens}},
+						},
+					},
+				},
+			}
+			factory, err := CreateModelFactoryFromConfig(cfg, "minimax-test/MiniMax-M3")
+			if err != nil {
+				t.Fatalf("CreateModelFactoryFromConfig: %v", err)
+			}
+			chatModel, err := factory.ChatModel(t.Context())
+			if err != nil {
+				t.Fatalf("ChatModel: %v", err)
+			}
+			if _, err := chatModel.Generate(t.Context(), []*schema.Message{schema.UserMessage("ping")}); err != nil {
+				t.Fatalf("Generate: %v", err)
+			}
+			if got := <-requestPath; got != tc.wantPath {
+				t.Fatalf("request path = %q, want %q", got, tc.wantPath)
+			}
+		})
 	}
 }
 

--- a/ui/src/ui/views/models-builtin.test.ts
+++ b/ui/src/ui/views/models-builtin.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { BUILTIN_PROVIDERS, parseModelRef, formatModelRef } from "./models-builtin.ts";
+import { getModelsForProvider } from "./models.ts";
 
 describe("BUILTIN_PROVIDERS MiniMax", () => {
   const minimax = BUILTIN_PROVIDERS.find((p) => p.id === "minimax");
@@ -8,8 +9,16 @@ describe("BUILTIN_PROVIDERS MiniMax", () => {
     expect(minimax).toBeDefined();
   });
 
-  it("uses MiniMax-M2.7 as default model", () => {
-    expect(minimax!.defaultModel).toBe("MiniMax-M2.7");
+  it("uses MiniMax-M3 as default model", () => {
+    expect(minimax!.defaultModel).toBe("MiniMax-M3");
+  });
+
+  it("lists MiniMax-M3 and MiniMax-M2.7", () => {
+    expect(minimax!.models).toEqual(["MiniMax-M3", "MiniMax-M2.7"]);
+    expect(getModelsForProvider("minimax")).toEqual([
+      { id: "MiniMax-M3", name: "MiniMax-M3" },
+      { id: "MiniMax-M2.7", name: "MiniMax-M2.7" },
+    ]);
   });
 
   it("uses Anthropic Messages API endpoint", () => {
@@ -58,6 +67,11 @@ describe("BUILTIN_PROVIDERS NEAR AI Cloud", () => {
 });
 
 describe("parseModelRef with MiniMax", () => {
+  it("parses minimax/MiniMax-M3", () => {
+    const result = parseModelRef("minimax/MiniMax-M3");
+    expect(result).toEqual({ provider: "minimax", modelId: "MiniMax-M3" });
+  });
+
   it("parses minimax/MiniMax-M2.7", () => {
     const result = parseModelRef("minimax/MiniMax-M2.7");
     expect(result).toEqual({ provider: "minimax", modelId: "MiniMax-M2.7" });
@@ -85,6 +99,10 @@ describe("parseModelRef with NEAR AI Cloud", () => {
 });
 
 describe("formatModelRef with MiniMax", () => {
+  it("formats the MiniMax-M3 model ref", () => {
+    expect(formatModelRef("minimax", "MiniMax-M3")).toBe("minimax/MiniMax-M3");
+  });
+
   it("formats minimax model ref correctly", () => {
     expect(formatModelRef("minimax", "MiniMax-M2.7")).toBe("minimax/MiniMax-M2.7");
   });

--- a/ui/src/ui/views/models-builtin.ts
+++ b/ui/src/ui/views/models-builtin.ts
@@ -8,6 +8,8 @@ export type BuiltInProvider = {
   label: string;
   envKey: string;
   defaultModel: string;
+  /** Built-in models shown when no provider config has been saved. */
+  models?: readonly string[];
   baseUrl: string;
   /** 默认 API 类型：openai-completions 或 anthropic-messages */
   defaultApi?: string;
@@ -31,7 +33,7 @@ export const BUILTIN_PROVIDERS: BuiltInProvider[] = [
   { id: "qianfan", label: "千帆 (百度)", envKey: "QIANFAN_API_KEY", defaultModel: "deepseek-v3-2-251201", baseUrl: "https://qianfan.baidubce.com/v2", defaultApi: "openai-completions" },
   { id: "huggingface", label: "Hugging Face", envKey: "HUGGINGFACE_HUB_TOKEN", defaultModel: "", baseUrl: "https://router.huggingface.co/v1", defaultApi: "openai-completions" },
   { id: "xiaomi", label: "小米 Mimo", envKey: "XIAOMI_API_KEY", defaultModel: "mimo-v2-flash", baseUrl: "https://api.xiaomimimo.com/anthropic", defaultApi: "anthropic-messages" },
-  { id: "minimax", label: "MiniMax", envKey: "MINIMAX_API_KEY", defaultModel: "MiniMax-M2.7", baseUrl: "https://api.minimax.io/anthropic", defaultApi: "anthropic-messages" },
+  { id: "minimax", label: "MiniMax", envKey: "MINIMAX_API_KEY", defaultModel: "MiniMax-M3", models: ["MiniMax-M3", "MiniMax-M2.7"], baseUrl: "https://api.minimax.io/anthropic", defaultApi: "anthropic-messages" },
   { id: "mistral", label: "Mistral", envKey: "MISTRAL_API_KEY", defaultModel: "mistral-large-latest", baseUrl: "https://api.mistral.ai/v1", defaultApi: "openai-completions" },
   { id: "groq", label: "Groq", envKey: "GROQ_API_KEY", defaultModel: "llama-3.3-70b-versatile", baseUrl: "https://api.groq.com/openai/v1", defaultApi: "openai-completions" },
   { id: "cerebras", label: "Cerebras", envKey: "CEREBRAS_API_KEY", defaultModel: "llama-4-scout-17b-16e-instruct", baseUrl: "https://api.cerebras.ai/v1", defaultApi: "openai-completions" },

--- a/ui/src/ui/views/models.ts
+++ b/ui/src/ui/views/models.ts
@@ -148,6 +148,7 @@ export function getModelsForProvider(providerKey: string, provider?: ModelProvid
   const builtin = BUILTIN_PROVIDERS.find((p) => p.id === providerKey);
   const configured = provider?.models ?? [];
   if (configured.length > 0) return configured;
+  if (builtin?.models?.length) return builtin.models.map((id) => ({ id, name: id }));
   if (builtin?.defaultModel) return [{ id: builtin.defaultModel, name: builtin.defaultModel }];
   return [];
 }


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- make MiniMax M3 the built-in default while retaining MiniMax M2.7
- expose both models in the UI and document global and China endpoint options for both supported API formats
- add request-capture coverage for compatible request paths

## Checks
- `git diff --check`
- `cd ui && npm test -- models-builtin.test.ts`
- `cd ui && npm run build`
- `cd src && GODEBUG=http2client=0 go test ./pkg/agent/eino`

## Baseline
- `cd ui && npm test` reproduces the same 17 unrelated failures on the unmodified base commit; the changed MiniMax test file passes.