### PR TITLE
Add Atlas Cloud model provider

### DIFF
--- a/docs/model-providers.md
+++ b/docs/model-providers.md
@@ -33,6 +33,7 @@
 | 厂商 (provider) | 认证环境变量 | 默认模型示例 | 默认 Base URL | API 类型 |
 |-----------------|-------------|--------------|---------------|----------|
 | **anthropic**   | `ANTHROPIC_API_KEY` | claude-sonnet-4-5-20250929 | (官方) | Anthropic |
+| **atlascloud**  | `ATLASCLOUD_API_KEY` | qwen/qwen3.5-flash | https://api.atlascloud.ai/v1 | OpenAI |
 | **openai**      | `OPENAI_API_KEY`    | gpt-4                       | (官方) | OpenAI |
 | **openrouter** | `OPENROUTER_API_KEY` | auto                        | https://openrouter.ai/api/v1 | OpenAI |
 | **litellm**     | `LITELLM_API_KEY`   | (需指定)                    | http://localhost:4000 | OpenAI |
@@ -117,6 +118,33 @@
         "default": true,
         "name": "Clawd",
         "model": "openai/gpt-4"
+      }
+    ]
+  }
+}
+```
+
+### Atlas Cloud
+
+Atlas Cloud 使用 OpenAI-compatible LLM endpoint。模型引用格式为 `atlascloud/<model-id>`。
+
+```json
+{
+  "env": {
+    "vars": {
+      "ATLASCLOUD_API_KEY": "your-atlascloud-api-key"
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": { "primary": "atlascloud/qwen/qwen3.5-flash" }
+    },
+    "list": [
+      {
+        "id": "main",
+        "default": true,
+        "name": "Clawd",
+        "model": "atlascloud/deepseek-ai/deepseek-v4-pro"
       }
     ]
   }

--- a/src/pkg/agent/eino/model_factory.go
+++ b/src/pkg/agent/eino/model_factory.go
@@ -22,6 +22,7 @@ type builtInProvider struct {
 }
 
 var builtInProviders = map[string]builtInProvider{
+	"atlascloud":        {"https://api.atlascloud.ai/v1", false, "ATLASCLOUD_API_KEY", "qwen/qwen3.5-flash"},
 	"openrouter":        {"https://openrouter.ai/api/v1", false, "OPENROUTER_API_KEY", "auto"},
 	"litellm":           {"http://localhost:4000", false, "LITELLM_API_KEY", ""},
 	"moonshot":          {"https://api.moonshot.ai/v1", false, "MOONSHOT_API_KEY", "kimi-k2.5"},

--- a/src/pkg/agent/eino/model_factory_test.go
+++ b/src/pkg/agent/eino/model_factory_test.go
@@ -55,6 +55,33 @@ func TestCreateModelFactoryFromConfig_MiniMax(t *testing.T) {
 	}
 }
 
+func TestCreateModelFactoryFromConfig_AtlasCloud(t *testing.T) {
+	t.Setenv("ATLASCLOUD_API_KEY", "test-key")
+	cfg := &config.OpenOctaConfig{
+		Models: &config.ModelsConfig{
+			Providers: map[string]config.ModelProvider{
+				"atlascloud": {
+					Models: []config.ModelDefinition{{ID: "qwen/qwen3.5-flash"}},
+				},
+			},
+		},
+	}
+	factory, err := CreateModelFactoryFromConfig(cfg, "atlascloud/qwen/qwen3.5-flash")
+	if err != nil {
+		t.Fatalf("CreateModelFactoryFromConfig: %v", err)
+	}
+	if factory == nil {
+		t.Fatal("expected non-nil factory")
+	}
+	_, err = factory.ChatModel(t.Context())
+	if err != nil {
+		// API key is fake; model construction should still succeed.
+		if os.Getenv("CI") != "" {
+			t.Fatalf("ChatModel: %v", err)
+		}
+	}
+}
+
 func TestCreateModelFactoryFromConfig_NearAI(t *testing.T) {
 	t.Setenv("NEARAI_API_KEY", "test-key")
 	cfg := &config.OpenOctaConfig{


### PR DESCRIPTION
## Summary
- add Atlas Cloud as a built-in OpenAI-compatible model provider
- use `ATLASCLOUD_API_KEY`, `https://api.atlascloud.ai/v1`, and `qwen/qwen3.5-flash` as the default model
- document Atlas Cloud in the existing model providers guide with an example using `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

## Validation
- `git diff --check`
- parsed the new Atlas Cloud JSON documentation example
- verified the Atlas Cloud live model catalog contains `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

Note: Go tests were not run locally because this environment does not have `go`/`gofmt` installed.
