### PR TITLE
fix(localbackend): add Read() override to reject directory reads

### DIFF
--- a/src/pkg/agent/eino/localbackend/backend.go
+++ b/src/pkg/agent/eino/localbackend/backend.go
@@ -80,6 +80,22 @@ func (b *Backend) Edit(ctx context.Context, req *filesystem.EditRequest) error {
 	return b.Local.Edit(ctx, &cp)
 }
 
+// Read resolves the target path and rejects directories before delegating.
+// The upstream Local.Read() does not check IsDir() on Unix, which would
+// silently return empty content for directories instead of a clear error.
+func (b *Backend) Read(ctx context.Context, req *filesystem.ReadRequest) (*filesystem.FileContent, error) {
+	if req == nil {
+		return nil, nil
+	}
+	path, err := ResolveWritablePath(req.FilePath, b.workspaceDir)
+	if err != nil {
+		return nil, err
+	}
+	cp := *req
+	cp.FilePath = path
+	return b.Local.Read(ctx, &cp)
+}
+
 // Ensure Backend satisfies filesystem interfaces used by DeepAgent.
 var (
 	_ filesystem.Backend        = (*Backend)(nil)


### PR DESCRIPTION
## Problem

`Backend` embeds `*localbk.Local` from `eino-ext` but doesn't override `Read()`. The upstream `Local.Read()` calls `os.Open()` followed by `Stat()`, but does **not** check `info.IsDir()` on Unix.

On Unix, `os.Open()` on a directory succeeds, and `Stat()` on a directory returns `Size() == 0`. The upstream method returns an empty `FileContent{}` with no error — silently masking the mistake.

`Write()` and `Edit()` **do** override the upstream with path resolution via `ResolveWritablePath()`, which includes an `info.IsDir()` check.

## Fix

Add `Read()` override that calls `ResolveWritablePath()` for path resolution and directory rejection, then delegates to `b.Local.Read()`.

Follows the exact same pattern as the existing `Write()` and `Edit()` overrides.

## Verification

- [ ] `go build` passes (blocks on first-time dep download due to eino package size; change is identical in structure to proven Write/Edit overrides)
- `_ filesystem.Backend = (*Backend)(nil)` compilation guard ensures interface satisfaction
- `ReadRequest` -> `Read(path)` -> `ResolveWritablePath` (isDir check) -> `Local.Read` (delegate) mirrors the existing pattern exactly
