### PR TITLE
fix: preserve streamed reasoning-model tool arguments

### DIFF
--- a/src/pkg/agent/eino/event_bridge.go
+++ b/src/pkg/agent/eino/event_bridge.go
@@ -203,6 +203,49 @@ type pendingToolCall struct {
 	name string
 }
 
+type streamedToolCall struct {
+	id        string
+	name      string
+	arguments strings.Builder
+}
+
+func appendStreamedToolCall(calls map[string]*streamedToolCall, index int, tc schema.ToolCall) {
+	key := strings.TrimSpace(tc.ID)
+	if key == "" {
+		key = fmt.Sprintf("index:%d", index)
+	}
+	call := calls[key]
+	if call == nil {
+		call = &streamedToolCall{}
+		calls[key] = call
+	}
+	if id := strings.TrimSpace(tc.ID); id != "" {
+		call.id = id
+	}
+	if name := strings.TrimSpace(tc.Function.Name); name != "" {
+		call.name = name
+	}
+	call.arguments.WriteString(tc.Function.Arguments)
+}
+
+func emitStreamedToolCalls(out chan<- stream.StreamEvent, sessionID string, calls map[string]*streamedToolCall) {
+	for _, call := range calls {
+		input := json.RawMessage(NormalizeToolCallArgumentsJSON(call.arguments.String()))
+		out <- stream.StreamEvent{
+			Type:      stream.EventToolExecutionStart,
+			SessionID: sessionID,
+			Name:      call.name,
+			ToolUseID: call.id,
+			ContentBlock: &stream.ContentBlock{
+				Type:  "tool_use",
+				ID:    call.id,
+				Name:  call.name,
+				Input: input,
+			},
+		}
+	}
+}
+
 func emitToolOutputAsResult(out chan<- stream.StreamEvent, sessionID string, pending pendingToolCall, output string) {
 	name := strings.TrimSpace(pending.name)
 	if name == "" {
@@ -327,6 +370,7 @@ func StreamEventsFromIterator(ctx context.Context, sessionID, runID string, iter
 				if mo.IsStreaming && mo.MessageStream != nil {
 					var lastReasoning string
 					var lastChunk *schema.Message
+					streamedCalls := make(map[string]*streamedToolCall)
 					for {
 						chunk, err := mo.MessageStream.Recv()
 						if err != nil {
@@ -362,23 +406,14 @@ func StreamEventsFromIterator(ctx context.Context, sessionID, runID string, iter
 						if text := visibleStreamingText(chunk); text != "" {
 							emitAssistantTextOrToolResult(out, sessionID, textStream, pending, text)
 						}
-						for _, tc := range chunk.ToolCalls {
-							input := json.RawMessage(NormalizeToolCallArgumentsJSON(tc.Function.Arguments))
-							pending.id = tc.ID
-							pending.name = tc.Function.Name
-							out <- stream.StreamEvent{
-								Type:      stream.EventToolExecutionStart,
-								SessionID: sessionID,
-								Name:      tc.Function.Name,
-								ToolUseID: tc.ID,
-								ContentBlock: &stream.ContentBlock{
-									Type:  "tool_use",
-									ID:    tc.ID,
-									Name:  tc.Function.Name,
-									Input: input,
-								},
-							}
+						for i, tc := range chunk.ToolCalls {
+							appendStreamedToolCall(streamedCalls, i, tc)
 						}
+					}
+					emitStreamedToolCalls(out, sessionID, streamedCalls)
+					for _, call := range streamedCalls {
+						pending.id = call.id
+						pending.name = call.name
 					}
 					if lastChunk != nil && emitTurnStopFromResponseMeta(out, sessionID, lastChunk.ResponseMeta, textStream) {
 						turnStopEmitted = true

--- a/src/pkg/agent/eino/event_bridge.go
+++ b/src/pkg/agent/eino/event_bridge.go
@@ -209,16 +209,37 @@ type streamedToolCall struct {
 	arguments strings.Builder
 }
 
-func appendStreamedToolCall(calls map[string]*streamedToolCall, index int, tc schema.ToolCall) {
+type streamedToolCalls struct {
+	calls   map[string]*streamedToolCall
+	byIndex map[int]string
+	order   []string
+}
+
+func appendStreamedToolCall(state *streamedToolCalls, index int, tc schema.ToolCall) {
 	key := strings.TrimSpace(tc.ID)
 	if key == "" {
-		key = fmt.Sprintf("index:%d", index)
+		key = state.byIndex[index]
+		if key == "" {
+			key = fmt.Sprintf("index:%d", index)
+		}
+	} else if previous := state.byIndex[index]; previous != "" && previous != key {
+		if call := state.calls[previous]; call != nil {
+			state.calls[key] = call
+			delete(state.calls, previous)
+			for i := range state.order {
+				if state.order[i] == previous {
+					state.order[i] = key
+				}
+			}
+		}
 	}
-	call := calls[key]
+	call := state.calls[key]
 	if call == nil {
 		call = &streamedToolCall{}
-		calls[key] = call
+		state.calls[key] = call
+		state.order = append(state.order, key)
 	}
+	state.byIndex[index] = key
 	if id := strings.TrimSpace(tc.ID); id != "" {
 		call.id = id
 	}
@@ -228,8 +249,9 @@ func appendStreamedToolCall(calls map[string]*streamedToolCall, index int, tc sc
 	call.arguments.WriteString(tc.Function.Arguments)
 }
 
-func emitStreamedToolCalls(out chan<- stream.StreamEvent, sessionID string, calls map[string]*streamedToolCall) {
-	for _, call := range calls {
+func emitStreamedToolCalls(out chan<- stream.StreamEvent, sessionID string, state *streamedToolCalls) {
+	for _, key := range state.order {
+		call := state.calls[key]
 		input := json.RawMessage(NormalizeToolCallArgumentsJSON(call.arguments.String()))
 		out <- stream.StreamEvent{
 			Type:      stream.EventToolExecutionStart,
@@ -370,7 +392,10 @@ func StreamEventsFromIterator(ctx context.Context, sessionID, runID string, iter
 				if mo.IsStreaming && mo.MessageStream != nil {
 					var lastReasoning string
 					var lastChunk *schema.Message
-					streamedCalls := make(map[string]*streamedToolCall)
+					streamedCalls := &streamedToolCalls{
+						calls:   make(map[string]*streamedToolCall),
+						byIndex: make(map[int]string),
+					}
 					for {
 						chunk, err := mo.MessageStream.Recv()
 						if err != nil {
@@ -411,7 +436,7 @@ func StreamEventsFromIterator(ctx context.Context, sessionID, runID string, iter
 						}
 					}
 					emitStreamedToolCalls(out, sessionID, streamedCalls)
-					for _, call := range streamedCalls {
+					for _, call := range streamedCalls.calls {
 						pending.id = call.id
 						pending.name = call.name
 					}

--- a/src/pkg/agent/eino/event_bridge_test.go
+++ b/src/pkg/agent/eino/event_bridge_test.go
@@ -1,6 +1,7 @@
 package eino
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/cloudwego/eino/schema"
@@ -9,6 +10,31 @@ import (
 	"github.com/openocta/openocta/pkg/agent/stream"
 	"github.com/openocta/openocta/pkg/agent/types"
 )
+
+func TestAppendStreamedToolCallAssemblesReasoningModelArguments(t *testing.T) {
+	calls := make(map[string]*streamedToolCall)
+	chunks := []schema.ToolCall{
+		{ID: "call_1", Function: schema.FunctionCall{Name: "memory_search"}},
+		{Function: schema.FunctionCall{Arguments: `{"query":`}},
+		{Function: schema.FunctionCall{Arguments: `"search-term"}`}},
+	}
+	for _, chunk := range chunks {
+		appendStreamedToolCall(calls, 0, chunk)
+	}
+
+	call := calls["call_1"]
+	if call == nil {
+		t.Fatal("expected tool call")
+	}
+	got := NormalizeToolCallArgumentsJSON(call.arguments.String())
+	var args map[string]string
+	if err := json.Unmarshal([]byte(got), &args); err != nil {
+		t.Fatalf("assembled arguments are invalid JSON: %v", err)
+	}
+	if args["query"] != "search-term" {
+		t.Fatalf("query = %q, want search-term", args["query"])
+	}
+}
 
 func TestBuildAgentMessagesUsesTranscriptHistory(t *testing.T) {
 	t.Parallel()

--- a/src/pkg/agent/eino/event_bridge_test.go
+++ b/src/pkg/agent/eino/event_bridge_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAppendStreamedToolCallAssemblesReasoningModelArguments(t *testing.T) {
-	calls := make(map[string]*streamedToolCall)
+	calls := &streamedToolCalls{calls: make(map[string]*streamedToolCall), byIndex: make(map[int]string)}
 	chunks := []schema.ToolCall{
 		{ID: "call_1", Function: schema.FunctionCall{Name: "memory_search"}},
 		{Function: schema.FunctionCall{Arguments: `{"query":`}},
@@ -22,7 +22,7 @@ func TestAppendStreamedToolCallAssemblesReasoningModelArguments(t *testing.T) {
 		appendStreamedToolCall(calls, 0, chunk)
 	}
 
-	call := calls["call_1"]
+	call := calls.calls["call_1"]
 	if call == nil {
 		t.Fatal("expected tool call")
 	}
@@ -33,6 +33,23 @@ func TestAppendStreamedToolCallAssemblesReasoningModelArguments(t *testing.T) {
 	}
 	if args["query"] != "search-term" {
 		t.Fatalf("query = %q, want search-term", args["query"])
+	}
+}
+
+func TestAppendStreamedToolCallAssociatesContinuationWithoutID(t *testing.T) {
+	calls := &streamedToolCalls{calls: make(map[string]*streamedToolCall), byIndex: make(map[int]string)}
+	appendStreamedToolCall(calls, 0, schema.ToolCall{
+		ID: "call_1", Function: schema.FunctionCall{Name: "memory_search"},
+	})
+	appendStreamedToolCall(calls, 0, schema.ToolCall{
+		Function: schema.FunctionCall{Arguments: `{"query":"term"}`},
+	})
+
+	if len(calls.calls) != 1 {
+		t.Fatalf("expected one assembled tool call, got %d", len(calls.calls))
+	}
+	if got := calls.calls["call_1"].arguments.String(); got != `{"query":"term"}` {
+		t.Fatalf("arguments = %q, want complete continuation", got)
 	}
 }
 


### PR DESCRIPTION
## Related issue
Fixes #105

## Background
Reasoning models stream `reasoning_content` before tool calls. Their tool-call arguments arrive as multiple fragments, but the stream bridge normalized each fragment independently. Incomplete fragments became `{}`, so tools such as `memory_search` received no `query`.

## Changes
- Accumulate streamed tool-call fragments by tool-call ID/index.
- Emit the tool execution event only after the stream has been assembled, then normalize the complete JSON object.
- Add a regression test covering reasoning-model-style fragmented arguments.

## Compatibility
Non-streaming tool calls are unchanged. Streaming tool calls now preserve complete argument JSON before invocation.

## Verification
- `gofmt -w src/pkg/agent/eino/event_bridge.go src/pkg/agent/eino/event_bridge_test.go`
- `go test ./pkg/agent/eino` — not completed in this environment; the command remained downloading large transitive dependencies and did not reach compilation within the available command window.

No Docker services are required for this unit-test-only change. Full lint/build checks were not run for the same dependency-download limitation.