### PR TITLE
Add MiniMax HTTP text to speech support

### DIFF
--- a/src/pkg/gateway/handlers/minimax_tts.go
+++ b/src/pkg/gateway/handlers/minimax_tts.go
@@ -1,0 +1,149 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const (
+	minimaxGlobalTTSEndpoint = "https://api.minimax.io/v1/t2a_v2"
+	minimaxChinaTTSEndpoint  = "https://api.minimaxi.com/v1/t2a_v2"
+	defaultMiniMaxTTSModel   = "speech-2.8-hd"
+)
+
+// MiniMaxSpeechRequest contains the HTTP text-to-audio fields supported by the
+// MiniMax speech endpoint. Optional fields are omitted when not configured.
+type MiniMaxSpeechRequest struct {
+	Model             string                 `json:"model"`
+	Text              string                 `json:"text"`
+	Stream            *bool                  `json:"stream,omitempty"`
+	LanguageBoost     string                 `json:"language_boost,omitempty"`
+	OutputFormat      string                 `json:"output_format,omitempty"`
+	VoiceSetting      map[string]interface{} `json:"voice_setting,omitempty"`
+	PronunciationDict map[string]interface{} `json:"pronunciation_dict,omitempty"`
+	AudioSetting      map[string]interface{} `json:"audio_setting,omitempty"`
+	VoiceModify       map[string]interface{} `json:"voice_modify,omitempty"`
+	SubtitleEnable    *bool                  `json:"subtitle_enable,omitempty"`
+}
+
+// MiniMaxSpeechResponse is the normalized result returned by Convert.
+type MiniMaxSpeechResponse struct {
+	Audio  []byte
+	Format string
+	Status int
+}
+
+type minimaxSpeechWireResponse struct {
+	Data struct {
+		Audio  string `json:"audio"`
+		Status int    `json:"status"`
+	} `json:"data"`
+	BaseResp struct {
+		StatusCode int    `json:"status_code"`
+		StatusMsg  string `json:"status_msg"`
+	} `json:"base_resp"`
+}
+
+// MiniMaxTTSProvider implements the synchronous regional MiniMax TTS API.
+type MiniMaxTTSProvider struct {
+	APIKey     string
+	Region     string
+	Endpoint   string
+	HTTPClient *http.Client
+}
+
+func NewMiniMaxTTSProvider(apiKey, region string) *MiniMaxTTSProvider {
+	p := &MiniMaxTTSProvider{APIKey: strings.TrimSpace(apiKey), Region: strings.TrimSpace(region), HTTPClient: http.DefaultClient}
+	p.Endpoint = miniMaxTTSEndpoint(p.Region)
+	return p
+}
+
+func miniMaxTTSEndpoint(region string) string {
+	if strings.EqualFold(strings.TrimSpace(region), "cn_zh") || strings.EqualFold(strings.TrimSpace(region), "china") {
+		return minimaxChinaTTSEndpoint
+	}
+	return minimaxGlobalTTSEndpoint
+}
+
+func (p *MiniMaxTTSProvider) Convert(ctx context.Context, request MiniMaxSpeechRequest) (*MiniMaxSpeechResponse, error) {
+	if p == nil || strings.TrimSpace(p.APIKey) == "" {
+		return nil, fmt.Errorf("minimax tts API key is not configured")
+	}
+	if strings.TrimSpace(request.Model) == "" {
+		request.Model = defaultMiniMaxTTSModel
+	}
+	if strings.TrimSpace(request.Text) == "" {
+		return nil, fmt.Errorf("text is required")
+	}
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("encode speech request: %w", err)
+	}
+	endpoint := p.Endpoint
+	if strings.TrimSpace(endpoint) == "" {
+		endpoint = miniMaxTTSEndpoint(p.Region)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create speech request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+p.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	client := p.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send speech request: %w", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read speech response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("speech endpoint returned HTTP %d", resp.StatusCode)
+	}
+	var wire minimaxSpeechWireResponse
+	if err := json.Unmarshal(responseBody, &wire); err != nil {
+		return nil, fmt.Errorf("decode speech response: %w", err)
+	}
+	if wire.BaseResp.StatusCode != 0 {
+		message := strings.TrimSpace(wire.BaseResp.StatusMsg)
+		if message == "" {
+			message = "request failed"
+		}
+		return nil, fmt.Errorf("minimax speech request failed (%d): %s", wire.BaseResp.StatusCode, message)
+	}
+	audio, err := decodeMiniMaxAudio(wire.Data.Audio)
+	if err != nil {
+		return nil, err
+	}
+	format := strings.TrimSpace(request.OutputFormat)
+	if format == "" {
+		format = "mp3"
+	}
+	return &MiniMaxSpeechResponse{Audio: audio, Format: format, Status: wire.Data.Status}, nil
+}
+
+func decodeMiniMaxAudio(value string) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, fmt.Errorf("minimax speech response did not include audio")
+	}
+	if decoded, err := hex.DecodeString(value); err == nil {
+		return decoded, nil
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(value); err == nil {
+		return decoded, nil
+	}
+	return nil, fmt.Errorf("minimax speech response audio is not valid hex or base64")
+}

--- a/src/pkg/gateway/handlers/minimax_tts_test.go
+++ b/src/pkg/gateway/handlers/minimax_tts_test.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMiniMaxTTSProviderConvert(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Fatalf("unexpected request metadata")
+		}
+		var request MiniMaxSpeechRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if request.Model != "speech-2.8-hd" || request.Text != "hello" || request.OutputFormat != "wav" {
+			t.Fatalf("unexpected request: %+v", request)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data":      map[string]interface{}{"audio": "6869", "status": 2},
+			"base_resp": map[string]interface{}{"status_code": 0},
+		})
+	}))
+	defer server.Close()
+
+	provider := NewMiniMaxTTSProvider("test-key", "global_en")
+	provider.Endpoint = server.URL
+	result, err := provider.Convert(context.Background(), MiniMaxSpeechRequest{Model: "speech-2.8-hd", Text: "hello", OutputFormat: "wav"})
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if string(result.Audio) != "hi" || result.Format != "wav" || result.Status != 2 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestMiniMaxTTSEndpoints(t *testing.T) {
+	if got := miniMaxTTSEndpoint("global_en"); got != minimaxGlobalTTSEndpoint {
+		t.Fatalf("global endpoint = %q", got)
+	}
+	if got := miniMaxTTSEndpoint("cn_zh"); got != minimaxChinaTTSEndpoint {
+		t.Fatalf("China endpoint = %q", got)
+	}
+}

--- a/src/pkg/gateway/handlers/tts.go
+++ b/src/pkg/gateway/handlers/tts.go
@@ -1,6 +1,11 @@
 package handlers
 
 import (
+	"context"
+	"encoding/base64"
+	"os"
+	"strings"
+
 	"github.com/openocta/openocta/pkg/gateway/protocol"
 )
 
@@ -14,6 +19,7 @@ type TtsStatusResult struct {
 	PrefsPath         string   `json:"prefsPath"`
 	HasOpenAIKey      bool     `json:"hasOpenAIKey"`
 	HasElevenLabsKey  bool     `json:"hasElevenLabsKey"`
+	HasMiniMaxKey     bool     `json:"hasMiniMaxKey"`
 	EdgeEnabled       bool     `json:"edgeEnabled"`
 }
 
@@ -24,6 +30,7 @@ func TtsStatusHandler(opts HandlerOpts) error {
 		Auto:              false,
 		Provider:          "openai",
 		FallbackProviders: []string{},
+		HasMiniMaxKey:     strings.TrimSpace(os.Getenv("MINIMAX_API_KEY")) != "",
 	}, nil, nil)
 	return nil
 }
@@ -31,7 +38,14 @@ func TtsStatusHandler(opts HandlerOpts) error {
 // TtsProvidersHandler handles "tts.providers".
 func TtsProvidersHandler(opts HandlerOpts) error {
 	opts.Respond(true, map[string]interface{}{
-		"providers": []interface{}{},
+		"providers": []interface{}{
+			map[string]interface{}{
+				"id":      "minimax",
+				"name":    "MiniMax",
+				"models":  []string{"speech-2.8-hd", "speech-2.8-turbo", "speech-2.6-hd", "speech-2.6-turbo", "speech-02-hd", "speech-02-turbo", "speech-01-hd", "speech-01-turbo"},
+				"formats": []string{"mp3", "wav", "flac", "pcm"},
+			},
+		},
 	}, nil, nil)
 	return nil
 }
@@ -56,6 +70,36 @@ func TtsConvertHandler(opts HandlerOpts) error {
 			Code:    protocol.ErrCodeInvalidRequest,
 			Message: "tts.convert requires text",
 		}, nil)
+		return nil
+	}
+	provider, _ := opts.Params["provider"].(string)
+	if strings.EqualFold(strings.TrimSpace(provider), "minimax") {
+		model, _ := opts.Params["model"].(string)
+		region, _ := opts.Params["region"].(string)
+		outputFormat, _ := opts.Params["output_format"].(string)
+		request := MiniMaxSpeechRequest{Model: model, Text: text, OutputFormat: outputFormat}
+		if stream, ok := opts.Params["stream"].(bool); ok {
+			request.Stream = &stream
+		}
+		if subtitle, ok := opts.Params["subtitle_enable"].(bool); ok {
+			request.SubtitleEnable = &subtitle
+		}
+		request.LanguageBoost, _ = opts.Params["language_boost"].(string)
+		request.VoiceSetting, _ = opts.Params["voice_setting"].(map[string]interface{})
+		request.PronunciationDict, _ = opts.Params["pronunciation_dict"].(map[string]interface{})
+		request.AudioSetting, _ = opts.Params["audio_setting"].(map[string]interface{})
+		request.VoiceModify, _ = opts.Params["voice_modify"].(map[string]interface{})
+		result, err := NewMiniMaxTTSProvider(os.Getenv("MINIMAX_API_KEY"), region).Convert(context.Background(), request)
+		if err != nil {
+			opts.Respond(false, nil, &protocol.ErrorShape{Code: protocol.ErrCodeServiceUnavailable, Message: err.Error()}, nil)
+			return nil
+		}
+		opts.Respond(true, map[string]interface{}{
+			"provider": "minimax",
+			"format":   result.Format,
+			"status":   result.Status,
+			"audio":    base64.StdEncoding.EncodeToString(result.Audio),
+		}, nil, nil)
 		return nil
 	}
 	opts.Respond(false, nil, &protocol.ErrorShape{


### PR DESCRIPTION
Reason: Add MiniMax text-to-speech support with regional HTTP endpoints, speech models, request fields, audio formats, and response parsing.

Implemented the MiniMax HTTP text-to-speech provider for global and China endpoints, including the documented speech models, request options, audio formats, and response decoding. The gateway TTS registry now exposes the provider and conversion requests return normalized base64 audio.

Checks:
- `go test ./pkg/gateway/handlers`
- Secret scan passed.
